### PR TITLE
Module doc fixes

### DIFF
--- a/docs/add_ldisk_module.rst
+++ b/docs/add_ldisk_module.rst
@@ -130,7 +130,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Drive Cache, 1 - Unchanged, 2 - Enabled,3 - Disabled.</div>
+                                            <div>Drive Cache, 1 - Unchanged, 2 - Enabled, 3 - Disabled.</div>
                                             <div>Required when <em>Info=None</em> and controller type is LSI.</div>
                                                         </td>
             </tr>
@@ -147,7 +147,7 @@ Parameters
                                                                                                                                                             </td>
                                                                 <td>
                                             <div>Raid controller ID.</div>
-                                            <div>Required when <em>Info=None</em> and controller type is LSI,PMC or MV.</div>
+                                            <div>Required when <em>Info=None</em> and controller type is LSI, PMC or MV.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -383,9 +383,9 @@ Parameters
                                                                             </td>
                                                                 <td>
                                             <div>Strip Size, 0 - 32k, 1 - 64k, 2 - 128k, 3 - 256k, 4 - 512k, 5 - 1024k.</div>
-                                            <div>Required when <em>Info=None</em> and controller type is LSI,PMC or MV.</div>
-                                            <div>When the controller type is MV,size is [0, 1].</div>
-                                            <div>When the controller type is LSI or PMC,size is [1, 2, 3, 4, 5].</div>
+                                            <div>Required when <em>Info=None</em> and controller type is LSI, PMC or MV.</div>
+                                            <div>When the controller type is MV, size is [0, 1].</div>
+                                            <div>When the controller type is LSI or PMC, size is [1, 2, 3, 4, 5].</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -400,7 +400,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Slot Num,input multiple slotNumber like 0,1,2....</div>
+                                            <div>Slot Num, input multiple slotNumber like 0, 1, 2....</div>
                                             <div>Required when <em>Info=None</em> and controller type is LSI or PMC.</div>
                                                         </td>
             </tr>
@@ -508,7 +508,7 @@ Examples
           cache: 1
           init: 2
           select: 10
-          slot: 0,1
+          slot: 0, 1
           provider: "{{ ksmanage }}"
 
       - name: "Add PMC ldisk"
@@ -517,7 +517,7 @@ Examples
           level: 1
           size: 1
           accelerator: 1
-          slot: 0,1
+          slot: 0, 1
           vname: "test"
           provider: "{{ ksmanage }}"
 

--- a/docs/backup_module.rst
+++ b/docs/backup_module.rst
@@ -132,7 +132,7 @@ Parameters
                                                                             </td>
                                                                 <td>
                                             <div>Export item.</div>
-                                            <div>The values for M5 modules are &#x27;all&#x27;, &#x27;network&#x27;, &#x27;service&#x27;, &#x27;ntp&#x27;, &#x27;snmptrap&#x27;, &#x27;dns&#x27;, &#x27;smtp&#x27;, &#x27;ad&#x27;, &#x27;ldap&#x27;, &#x27;user&#x27;,&#x27;bios&#x27;.</div>
+                                            <div>The values for M5 modules are &#x27;all&#x27;, &#x27;network&#x27;, &#x27;service&#x27;, &#x27;ntp&#x27;, &#x27;snmptrap&#x27;, &#x27;dns&#x27;, &#x27;smtp&#x27;, &#x27;ad&#x27;, &#x27;ldap&#x27;, &#x27;user&#x27;, &#x27;bios&#x27;.</div>
                                             <div>The values for M6 modules are &#x27;all&#x27;, &#x27;network&#x27;, &#x27;service&#x27;, &#x27;ntp&#x27;, &#x27;snmptrap&#x27;,  &#x27;kvm&#x27;, &#x27;ipmi&#x27;, &#x27;authentication&#x27;, &#x27;syslog&#x27;.</div>
                                             <div>The values for M7 modules are &#x27;all&#x27;, &#x27;network&#x27;, &#x27;service&#x27;, &#x27;syslog&#x27;, &#x27;ncsi&#x27;.</div>
                                                         </td>

--- a/docs/bios_export_module.rst
+++ b/docs/bios_export_module.rst
@@ -83,7 +83,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Suffix is .json/.conf, FILEURI format,&quot;/directory/filename&quot;.</div>
+                                            <div>Suffix is .json/.conf, FILEURI format, &quot;/directory/filename&quot;.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/bios_import_module.rst
+++ b/docs/bios_import_module.rst
@@ -83,7 +83,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Suffix is .json/.conf, FILEURI format,&quot;/directory/filename&quot;.</div>
+                                            <div>Suffix is .json/.conf, FILEURI format, &quot;/directory/filename&quot;.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/collect_log_module.rst
+++ b/docs/collect_log_module.rst
@@ -42,7 +42,7 @@ Synopsis
 
 .. Description
 
-- Collect logs on kaytus Server,it takes about 5 minutes.
+- Collect logs on kaytus Server, it takes about 5 minutes.
 
 
 .. Aliases

--- a/docs/edit_alert_policy_module.rst
+++ b/docs/edit_alert_policy_module.rst
@@ -103,9 +103,9 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Alert destination,when type is snmp,fill in IP.</div>
-                                            <div>When type is email,fill in user name.</div>
-                                            <div>When type is snmpdomain,fill in domain.</div>
+                                            <div>Alert destination, when type is snmp, fill in IP.</div>
+                                            <div>When type is email, fill in user name.</div>
+                                            <div>When type is snmpdomain, fill in domain.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -142,8 +142,8 @@ Parameters
                                                                             </td>
                                                                 <td>
                                             <div>Alert id.</div>
-                                            <div>The values for M5 modules are 1,2,3.</div>
-                                            <div>The values for M6 modules are 1,2,3,4.</div>
+                                            <div>The values for M5 modules are 1, 2, 3.</div>
+                                            <div>The values for M6 modules are 1, 2, 3, 4.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_alert_policy_module.rst
+++ b/docs/edit_alert_policy_module.rst
@@ -103,9 +103,9 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Alert destination, when type is snmp, fill in IP.</div>
-                                            <div>When type is email, fill in user name.</div>
-                                            <div>When type is snmpdomain, fill in domain.</div>
+                                            <div>Alert destination, when type is snmp, specify an IP address.</div>
+                                            <div>When type is email, specify a username.</div>
+                                            <div>When type is snmpdomain, specify a domain.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_bios_module.rst
+++ b/docs/edit_bios_module.rst
@@ -100,7 +100,7 @@ Parameters
                                                                                                                                                             </td>
                                                                 <td>
                                             <div>BIOS option file.attribute must be used with value.</div>
-                                            <div>Mutually exclusive with fileurl format,&quot;/directory/filename&quot;.</div>
+                                            <div>Mutually exclusive with fileurl format, &quot;/directory/filename&quot;.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_dns_module.rst
+++ b/docs/edit_dns_module.rst
@@ -83,7 +83,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>DNS Interface,input like &#x27;eth0&#x27;, &#x27;eth1&#x27;, &#x27;bond0&#x27;.</div>
+                                            <div>DNS Interface, input like &#x27;eth0&#x27;, &#x27;eth1&#x27;, &#x27;bond0&#x27;.</div>
                                             <div>Required when <em>dns_manual=auto</em>.</div>
                                                         </td>
             </tr>
@@ -205,7 +205,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Network Interface,input like &#x27;eth0_v4&#x27;, &#x27;eth0_v6&#x27;, &#x27;eth1_v4&#x27;, &#x27;eth1_v6&#x27;, &#x27;bond0_v4&#x27;, &#x27;bond0_v6&#x27;.</div>
+                                            <div>Network Interface, input like &#x27;eth0_v4&#x27;, &#x27;eth0_v6&#x27;, &#x27;eth1_v4&#x27;, &#x27;eth1_v6&#x27;, &#x27;bond0_v4&#x27;, &#x27;bond0_v6&#x27;.</div>
                                             <div>Required when <em>domain_manual=auto</em>.</div>
                                                         </td>
             </tr>

--- a/docs/edit_fan_module.rst
+++ b/docs/edit_fan_module.rst
@@ -113,7 +113,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Fan id 255 is for all fans,0~n.</div>
+                                            <div>Fan id 255 is for all fans, 0~n.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -132,7 +132,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Control mode, Manual or Automatic ,Manual must be used with fans_peed.</div>
+                                            <div>Control mode, Manual or Automatic , Manual must be used with fans_peed.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_fru_module.rst
+++ b/docs/edit_fru_module.rst
@@ -97,10 +97,10 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>CP is Chassis Part Number,CS is Chassis Serial,PM is Product Manufacturer.</div>
-                                            <div>PPN is Product Part Number,PS is Product Serial,PN is Product Name.</div>
-                                            <div>PV is Product Version,PAT is Product Asset Tag,BM is Board Mfg,BPN is Board Product Name.</div>
-                                            <div>BS is Board Serial,BP is Board Part Number.</div>
+                                            <div>CP is Chassis Part Number, CS is Chassis Serial, PM is Product Manufacturer.</div>
+                                            <div>PPN is Product Part Number, PS is Product Serial, PN is Product Name.</div>
+                                            <div>PV is Product Version, PAT is Product Asset Tag, BM is Board Mfg, BPN is Board Product Name.</div>
+                                            <div>BS is Board Serial, BP is Board Part Number.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_kvm_module.rst
+++ b/docs/edit_kvm_module.rst
@@ -160,7 +160,7 @@ Parameters
                                                                 <td>
                                             <div>Select the Keyboard Language.</div>
                                             <div>AD is Auto Detect, DA is Danish, NL-BE is Dutch Belgium, NL-NL is Dutch Netherland.</div>
-                                            <div>GB is English UK ,US is English US, FI is Finnish, FR-BE is French Belgium, FR is French France.</div>
+                                            <div>GB is English UK , US is English US, FI is Finnish, FR-BE is French Belgium, FR is French France.</div>
                                             <div>DE is German Germany, DE-CH is German Switzerland, IT is Italian, JP is Japanese.</div>
                                             <div>NO is Norwegian, PT is Portuguese, ES is Spanish, SV is Swedish, TR_F is Turkish F, TR_Q is Turkish Q.</div>
                                                         </td>

--- a/docs/edit_ldap_module.rst
+++ b/docs/edit_ldap_module.rst
@@ -120,7 +120,7 @@ Parameters
                                             <div>Search Base.</div>
                                             <div>Search base is a string of 4 to 64 alpha-numeric characters.</div>
                                             <div>It must start with an alphabetical character.</div>
-                                            <div>Special Symbols like dot(.), comma(,), hyphen(-), underscore(_), equal-to(=) are allowed.</div>
+                                            <div>Special Symbols like dot(.), comma(, ), hyphen(-), underscore(_), equal-to(=) are allowed.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -206,7 +206,7 @@ Parameters
                                             <div>Bind DN.</div>
                                             <div>Bind DN is a string of 4 to 64 alpha-numeric characters.</div>
                                             <div>It must start with an alphabetical character.</div>
-                                            <div>Special Symbols like dot(.), comma(,), hyphen(-), underscore(_), equal-to(=) are allowed.</div>
+                                            <div>Special Symbols like dot(.), comma(, ), hyphen(-), underscore(_), equal-to(=) are allowed.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -433,7 +433,7 @@ Examples
           encry: "SSL"
           address: "100.2.2.2"
           server_port: 389
-          dn: "cn=manager,ou=login,dc=domain,dc=com"
+          dn: "cn=manager, ou=login, dc=domain, dc=com"
           code: "123456"
           base: "cn=manager"
           attr: "uid"

--- a/docs/edit_ldap_module.rst
+++ b/docs/edit_ldap_module.rst
@@ -118,7 +118,7 @@ Parameters
                                                                                                                                                             </td>
                                                                 <td>
                                             <div>Search Base.</div>
-                                            <div>Search base is a string of 4 to 64 alpha-numeric characters.</div>
+                                            <div>Search base is a string of 4 to 64 alphanumeric characters.</div>
                                             <div>It must start with an alphabetical character.</div>
                                             <div>Special Symbols like dot(.), comma(, ), hyphen(-), underscore(_), equal-to(=) are allowed.</div>
                                                         </td>
@@ -204,7 +204,7 @@ Parameters
                                                                                                                                                             </td>
                                                                 <td>
                                             <div>Bind DN.</div>
-                                            <div>Bind DN is a string of 4 to 64 alpha-numeric characters.</div>
+                                            <div>Bind DN is a string of 4 to 64 alphanumeric characters.</div>
                                             <div>It must start with an alphabetical character.</div>
                                             <div>Special Symbols like dot(.), comma(, ), hyphen(-), underscore(_), equal-to(=) are allowed.</div>
                                                         </td>

--- a/docs/edit_ldisk_module.rst
+++ b/docs/edit_ldisk_module.rst
@@ -173,7 +173,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Set operation options fo logical disk.</div>
+                                            <div>Set operation options for a logical disk.</div>
                                             <div>LOC is Locate Logical Drive, STL is Stop Locate LogicalDrive.</div>
                                             <div>FI is Fast Initialization, SFI is Slow/Full Initialization.</div>
                                             <div>SI is Stop Initialization, DEL is Delete LogicalDrive.</div>

--- a/docs/edit_ldisk_module.rst
+++ b/docs/edit_ldisk_module.rst
@@ -99,7 +99,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Duration range is 1-255,physical drive under PMC raid controller.</div>
+                                            <div>Duration range is 1-255, physical drive under PMC raid controller.</div>
                                             <div>Required when <em>option=LOC</em>.</div>
                                             <div>Only the M6 model supports this parameter.</div>
                                                         </td>
@@ -174,9 +174,9 @@ Parameters
                                                                             </td>
                                                                 <td>
                                             <div>Set operation options fo logical disk.</div>
-                                            <div>LOC is Locate Logical Drive,STL is Stop Locate LogicalDrive.</div>
-                                            <div>FI is Fast Initialization,SFI is Slow/Full Initialization.</div>
-                                            <div>SI is Stop Initialization,DEL is Delete LogicalDrive.</div>
+                                            <div>LOC is Locate Logical Drive, STL is Stop Locate LogicalDrive.</div>
+                                            <div>FI is Fast Initialization, SFI is Slow/Full Initialization.</div>
+                                            <div>SI is Stop Initialization, DEL is Delete LogicalDrive.</div>
                                             <div>Required when <em>Info=None</em>.</div>
                                                         </td>
             </tr>

--- a/docs/edit_m6_log_setting_module.rst
+++ b/docs/edit_m6_log_setting_module.rst
@@ -104,7 +104,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>System log host tag,set when <em>status=enable</em>.</div>
+                                            <div>System log host tag, set when <em>status=enable</em>.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -124,7 +124,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Events Level,set when <em>status=enable</em>.</div>
+                                            <div>Events Level, set when <em>status=enable</em>.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -144,7 +144,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Remote Log Type,set when server_id is not none.</div>
+                                            <div>Remote Log Type, set when server_id is not none.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -178,7 +178,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Protocol Type,set when <em>status=enable</em>.</div>
+                                            <div>Protocol Type, set when <em>status=enable</em>.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -257,7 +257,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Server Address,set when server_id is not none.</div>
+                                            <div>Server Address, set when server_id is not none.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -278,7 +278,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Syslog Server ID,set when <em>status=enable</em>.</div>
+                                            <div>Syslog Server ID, set when <em>status=enable</em>.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -293,7 +293,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Server Address,set when server_id is not none.</div>
+                                            <div>Server Address, set when server_id is not none.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -331,7 +331,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Test remote log settings,set when server_id is not none.</div>
+                                            <div>Test remote log settings, set when server_id is not none.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_ncsi_module.rst
+++ b/docs/edit_ncsi_module.rst
@@ -166,7 +166,7 @@ Parameters
                                                                 <td>
                                             <div>Nic type.</div>
                                             <div>Only NF3280A6 and NF3180A6 model supports <code>Disable</code> Settings, but not support <code>PHY</code> Settings.</div>
-                                            <div>M6 model only support <code>OCP</code>,<code>OCP1</code>,<code>PCIE</code> settings.</div>
+                                            <div>M6 model only support <code>OCP</code>, <code>OCP1</code>, <code>PCIE</code> settings.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_network_bond_module.rst
+++ b/docs/edit_network_bond_module.rst
@@ -106,7 +106,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Network bond status,If VLAN is enabled for slave interfaces, then Bonding cannot be enabled.</div>
+                                            <div>Network bond status, If VLAN is enabled for slave interfaces, then Bonding cannot be enabled.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_network_module.rst
+++ b/docs/edit_network_module.rst
@@ -42,7 +42,7 @@ Synopsis
 
 .. Description
 
-- Set netowrk information on kaytus Server.
+- Set network information on kaytus Server.
 
 
 .. Aliases

--- a/docs/edit_ntp_module.rst
+++ b/docs/edit_ntp_module.rst
@@ -117,7 +117,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>NTP Maximum jump time(minute),max variety(1-60).</div>
+                                            <div>NTP Maximum jump time(minute), max variety(1-60).</div>
                                             <div>Only the M6 model supports this parameter.</div>
                                                         </td>
             </tr>
@@ -318,7 +318,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>NTP syn cycle(minute),sync cycle(5-1440).</div>
+                                            <div>NTP syn cycle(minute), sync cycle(5-1440).</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -333,7 +333,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>UTC time zone,chose from {-12, -11.5, -11, ... ,11,11.5,12}.</div>
+                                            <div>UTC time zone, chose from {-12, -11.5, -11, ... , 11, 11.5, 12}.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_pdisk_module.rst
+++ b/docs/edit_pdisk_module.rst
@@ -241,7 +241,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Set operation options fo physical disk.</div>
+                                            <div>Set operation options for a physical disk.</div>
                                             <div>UG is Unconfigured Good, UB is Unconfigured Bad.</div>
                                             <div>OFF is offline, FAIL is Failed, RBD is Rebuild.</div>
                                             <div>ON is Online, JB is JBOD, ES is Drive Erase stop.</div>

--- a/docs/edit_pdisk_module.rst
+++ b/docs/edit_pdisk_module.rst
@@ -137,7 +137,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Duration range is 1-255,physical drive under PMC raid controller.</div>
+                                            <div>Duration range is 1-255, physical drive under PMC raid controller.</div>
                                             <div>Required when <em>option=LOC</em>.</div>
                                             <div>Only the M6 model supports this parameter.</div>
                                                         </td>
@@ -208,7 +208,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Logical Drivers while set physical drive hotspare, input multiple Logical Drivers index like 0,1,2.....</div>
+                                            <div>Logical Drivers while set physical drive hotspare, input multiple Logical Drivers index like 0, 1, 2.....</div>
                                             <div>Required when <em>Info=None</em> and <em>option=HS</em> and <em>action=dedicate</em>.</div>
                                             <div>Only the M5 model supports this parameter.</div>
                                                         </td>
@@ -242,11 +242,11 @@ Parameters
                                                                             </td>
                                                                 <td>
                                             <div>Set operation options fo physical disk.</div>
-                                            <div>UG is Unconfigured Good,UB is Unconfigured Bad.</div>
-                                            <div>OFF is offline,FAIL is Failed,RBD is Rebuild.</div>
-                                            <div>ON is Online,JB is JBOD,ES is Drive Erase stop.</div>
-                                            <div>EM is Drive Erase Simple,EN is Drive Erase Normal.</div>
-                                            <div>ET is Drive Erase Through,LOC is Locate,STL is Stop Locate.</div>
+                                            <div>UG is Unconfigured Good, UB is Unconfigured Bad.</div>
+                                            <div>OFF is offline, FAIL is Failed, RBD is Rebuild.</div>
+                                            <div>ON is Online, JB is JBOD, ES is Drive Erase stop.</div>
+                                            <div>EM is Drive Erase Simple, EN is Drive Erase Normal.</div>
+                                            <div>ET is Drive Erase Through, LOC is Locate, STL is Stop Locate.</div>
                                             <div>HS is Hot spare.</div>
                                             <div>Required when <em>Info=None</em>.</div>
                                             <div>Only the M5 model supports <code>HS</code> Settings.</div>

--- a/docs/edit_power_budget_module.rst
+++ b/docs/edit_power_budget_module.rst
@@ -463,7 +463,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Their&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
+                                            <div>Pause period of add, repetition period.</div>
+                                            <div>The input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -478,7 +479,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Their&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
+                                            <div>Pause period of add, repetition period.</div>
+                                            <div>The input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -493,7 +495,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Their&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
+                                            <div>Pause period of add, repetition period.</div>
+                                            <div>The input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -508,7 +511,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Their&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
+                                            <div>Pause period of add, repetition period.</div>
+                                            <div>The input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -523,7 +527,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Their&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
+                                            <div>Pause period of add, repetition period.</div>
+                                            <div>The input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                         </table>

--- a/docs/edit_power_budget_module.rst
+++ b/docs/edit_power_budget_module.rst
@@ -463,7 +463,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
+                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Their&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -478,7 +478,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
+                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Their&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -493,7 +493,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
+                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Their&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -508,7 +508,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
+                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Their&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -523,7 +523,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
+                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Their&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                         </table>

--- a/docs/edit_power_budget_module.rst
+++ b/docs/edit_power_budget_module.rst
@@ -125,7 +125,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, end time,must be greater than start time,from 0 to 24.</div>
+                                            <div>Pause period of add, end time, must be greater than start time, from 0 to 24.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -140,7 +140,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, end time,must be greater than start time,from 0 to 24.</div>
+                                            <div>Pause period of add, end time, must be greater than start time, from 0 to 24.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -155,7 +155,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, end time,must be greater than start time,from 0 to 24.</div>
+                                            <div>Pause period of add, end time, must be greater than start time, from 0 to 24.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -170,7 +170,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, end time,must be greater than start time,from 0 to 24.</div>
+                                            <div>Pause period of add, end time, must be greater than start time, from 0 to 24.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -185,7 +185,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add, end time,must be greater than start time,from 0 to 24.</div>
+                                            <div>Pause period of add, end time, must be greater than start time, from 0 to 24.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -463,7 +463,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add,repetition period,the input parameters are &#x27;Mon&#x27;,&#x27;Tue&#x27;,&#x27;Wed&#x27;,&#x27;Thur&#x27;,&#x27;Fri&#x27;,&#x27;Sat&#x27;,&#x27;Sun&#x27;,separated by commas,such as Mon,Wed,Fri.</div>
+                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -478,7 +478,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add,repetition period,the input parameters are &#x27;Mon&#x27;,&#x27;Tue&#x27;,&#x27;Wed&#x27;,&#x27;Thur&#x27;,&#x27;Fri&#x27;,&#x27;Sat&#x27;,&#x27;Sun&#x27;,separated by commas,such as Mon,Wed,Fri.</div>
+                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -493,7 +493,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add,repetition period,the input parameters are &#x27;Mon&#x27;,&#x27;Tue&#x27;,&#x27;Wed&#x27;,&#x27;Thur&#x27;,&#x27;Fri&#x27;,&#x27;Sat&#x27;,&#x27;Sun&#x27;,separated by commas,such as Mon,Wed,Fri.</div>
+                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -508,7 +508,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add,repetition period,the input parameters are &#x27;Mon&#x27;,&#x27;Tue&#x27;,&#x27;Wed&#x27;,&#x27;Thur&#x27;,&#x27;Fri&#x27;,&#x27;Sat&#x27;,&#x27;Sun&#x27;,separated by commas,such as Mon,Wed,Fri.</div>
+                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -523,7 +523,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Pause period of add,repetition period,the input parameters are &#x27;Mon&#x27;,&#x27;Tue&#x27;,&#x27;Wed&#x27;,&#x27;Thur&#x27;,&#x27;Fri&#x27;,&#x27;Sat&#x27;,&#x27;Sun&#x27;,separated by commas,such as Mon,Wed,Fri.</div>
+                                            <div>Pause period of add, repetition period, the input parameters are &#x27;Mon&#x27;, &#x27;Tue&#x27;, &#x27;Wed&#x27;, &#x27;Thur&#x27;, &#x27;Fri&#x27;, &#x27;Sat&#x27;, &#x27;Sun&#x27;, separated by commas, such as Mon, Wed, Fri.</div>
                                                         </td>
             </tr>
                         </table>

--- a/docs/edit_smtp_com_module.rst
+++ b/docs/edit_smtp_com_module.rst
@@ -304,7 +304,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>SMTP server Password,lenth be 4 to 64 bits,cannot contain &#x27; &#x27;(space).</div>
+                                            <div>SMTP server Password, lenth be 4 to 64 bits, cannot contain &#x27; &#x27;(space).</div>
                                             <div>Required when <em>server_auth=enable</em>.</div>
                                                         </td>
             </tr>
@@ -320,7 +320,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>SMTP server port,The Identification for retry count configuration(1-65535).</div>
+                                            <div>SMTP server port, The Identification for retry count configuration(1-65535).</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -335,7 +335,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>SMTP server sesure port,The Identification for retry count configuration(1-65535).</div>
+                                            <div>SMTP server sesure port, The Identification for retry count configuration(1-65535).</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -350,8 +350,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>SMTP server Username,lenth be 4 to 64 bits.</div>
-                                            <div>Must start with letters and cannot contain &#x27;,&#x27;(comma) &#x27;:&#x27;(colon) &#x27; &#x27;(space) &#x27;;&#x27;(semicolon) &#x27;\&#x27;(backslash).</div>
+                                            <div>SMTP server Username, lenth be 4 to 64 bits.</div>
+                                            <div>Must start with letters and cannot contain &#x27;, &#x27;(comma) &#x27;:&#x27;(colon) &#x27; &#x27;(space) &#x27;;&#x27;(semicolon) &#x27;\&#x27;(backslash).</div>
                                             <div>Required when <em>server_auth=enable</em>.</div>
                                                         </td>
             </tr>

--- a/docs/edit_smtp_com_module.rst
+++ b/docs/edit_smtp_com_module.rst
@@ -304,7 +304,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>SMTP server Password, lenth be 4 to 64 bits, cannot contain &#x27; &#x27;(space).</div>
+                                            <div>SMTP server Password, length be 4 to 64 bits, cannot contain &#x27; &#x27;(space).</div>
                                             <div>Required when <em>server_auth=enable</em>.</div>
                                                         </td>
             </tr>
@@ -350,7 +350,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>SMTP server Username, lenth be 4 to 64 bits.</div>
+                                            <div>SMTP server Username, length be 4 to 64 bits.</div>
                                             <div>Must start with letters and cannot contain &#x27;, &#x27;(comma) &#x27;:&#x27;(colon) &#x27; &#x27;(space) &#x27;;&#x27;(semicolon) &#x27;\&#x27;(backslash).</div>
                                             <div>Required when <em>server_auth=enable</em>.</div>
                                                         </td>

--- a/docs/edit_smtp_module.rst
+++ b/docs/edit_smtp_module.rst
@@ -119,7 +119,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>LAN Channel,eth0 is shared,eth1 is dedicated.</div>
+                                            <div>LAN Channel, eth0 is shared, eth1 is dedicated.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -198,7 +198,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Primary SMTP server Password,lenth be 4 to 64 bits,cannot contain &#x27; &#x27;(space).</div>
+                                            <div>Primary SMTP server Password, lenth be 4 to 64 bits, cannot contain &#x27; &#x27;(space).</div>
                                             <div>Required when <em>primary_auth=enable</em>.</div>
                                                         </td>
             </tr>
@@ -214,7 +214,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Primary SMTP server port,The Identification for retry count configuration(1-65535).</div>
+                                            <div>Primary SMTP server port, The Identification for retry count configuration(1-65535).</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -248,8 +248,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Primary SMTP server Username,lenth be 4 to 64 bits.</div>
-                                            <div>Must start with letters and cannot contain &#x27;,&#x27;(comma) &#x27;:&#x27;(colon) &#x27; &#x27;(space) &#x27;;&#x27;(semicolon) &#x27;\&#x27;(backslash).</div>
+                                            <div>Primary SMTP server Username, lenth be 4 to 64 bits.</div>
+                                            <div>Must start with letters and cannot contain &#x27;, &#x27;(comma) &#x27;:&#x27;(colon) &#x27; &#x27;(space) &#x27;;&#x27;(semicolon) &#x27;\&#x27;(backslash).</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -377,7 +377,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Secondary SMTP server Password,lenth be 4 to 64 bits,cannot contain &#x27; &#x27;(space).</div>
+                                            <div>Secondary SMTP server Password, lenth be 4 to 64 bits, cannot contain &#x27; &#x27;(space).</div>
                                             <div>Required when <em>secondary_auth=enable</em>.</div>
                                                         </td>
             </tr>
@@ -393,7 +393,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Secondary SMTP server port,The Identification for retry count configuration(1-65535).</div>
+                                            <div>Secondary SMTP server port, The Identification for retry count configuration(1-65535).</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -427,8 +427,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Secondary SMTP server Username,lenth be 4 to 64 bits.</div>
-                                            <div>Must start with letters and cannot contain &#x27;,&#x27;(comma) &#x27;:&#x27;(colon) &#x27; &#x27;(space) &#x27;;&#x27;(semicolon) &#x27;\&#x27;(backslash).</div>
+                                            <div>Secondary SMTP server Username, lenth be 4 to 64 bits.</div>
+                                            <div>Must start with letters and cannot contain &#x27;, &#x27;(comma) &#x27;:&#x27;(colon) &#x27; &#x27;(space) &#x27;;&#x27;(semicolon) &#x27;\&#x27;(backslash).</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_smtp_module.rst
+++ b/docs/edit_smtp_module.rst
@@ -198,7 +198,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Primary SMTP server Password, lenth be 4 to 64 bits, cannot contain &#x27; &#x27;(space).</div>
+                                            <div>Primary SMTP server Password, length be 4 to 64 bits, cannot contain &#x27; &#x27;(space).</div>
                                             <div>Required when <em>primary_auth=enable</em>.</div>
                                                         </td>
             </tr>
@@ -248,7 +248,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Primary SMTP server Username, lenth be 4 to 64 bits.</div>
+                                            <div>Primary SMTP server Username, length be 4 to 64 bits.</div>
                                             <div>Must start with letters and cannot contain &#x27;, &#x27;(comma) &#x27;:&#x27;(colon) &#x27; &#x27;(space) &#x27;;&#x27;(semicolon) &#x27;\&#x27;(backslash).</div>
                                                         </td>
             </tr>
@@ -377,7 +377,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Secondary SMTP server Password, lenth be 4 to 64 bits, cannot contain &#x27; &#x27;(space).</div>
+                                            <div>Secondary SMTP server Password, length be 4 to 64 bits, cannot contain &#x27; &#x27;(space).</div>
                                             <div>Required when <em>secondary_auth=enable</em>.</div>
                                                         </td>
             </tr>
@@ -427,7 +427,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Secondary SMTP server Username, lenth be 4 to 64 bits.</div>
+                                            <div>Secondary SMTP server Username, length be 4 to 64 bits.</div>
                                             <div>Must start with letters and cannot contain &#x27;, &#x27;(comma) &#x27;:&#x27;(colon) &#x27; &#x27;(space) &#x27;;&#x27;(semicolon) &#x27;\&#x27;(backslash).</div>
                                                         </td>
             </tr>

--- a/docs/edit_snmp_module.rst
+++ b/docs/edit_snmp_module.rst
@@ -84,7 +84,7 @@ Parameters
                                                                                                                                                             </td>
                                                                 <td>
                                             <div>Set auth password of V3 trap or v3get/v3set.</div>
-                                            <div>Password is a string of 8 to 16 alpha-numeric characters.</div>
+                                            <div>Password is a string of 8 to 16 alphanumeric characters.</div>
                                             <div>Required when <em>auth_protocol</em> is either <code>SHA</code> or <code>MD5</code>.</div>
                                                         </td>
             </tr>
@@ -167,7 +167,7 @@ Parameters
                                                                                                                                                             </td>
                                                                 <td>
                                             <div>Set privacy password of V3 trap or v3get/v3set.</div>
-                                            <div>Password is a string of 8 to 16 alpha-numeric characters.</div>
+                                            <div>Password is a string of 8 to 16 alphanumeric characters.</div>
                                             <div>Required when <em>priv_protocol</em> is either <code>DES</code> or <code>AES</code>.</div>
                                                         </td>
             </tr>

--- a/docs/edit_snmp_module.rst
+++ b/docs/edit_snmp_module.rst
@@ -267,7 +267,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Read Only Community,Community should between 1 and 16 characters.</div>
+                                            <div>Read Only Community, Community should between 1 and 16 characters.</div>
                                             <div>Only the M6 models support this feature.</div>
                                                         </td>
             </tr>
@@ -283,7 +283,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Read And Write Community,Community should between 1 and 16 characters.</div>
+                                            <div>Read And Write Community, Community should between 1 and 16 characters.</div>
                                             <div>Only the M6 models support this feature.</div>
                                                         </td>
             </tr>
@@ -300,7 +300,7 @@ Parameters
                                                                                                                                                             </td>
                                                                 <td>
                                             <div>NMP read/write status of customize.</div>
-                                            <div>The input parameters are &#x27;v1get&#x27;, &#x27;v1set&#x27;, &#x27;v2cget&#x27;, &#x27;v2cset&#x27;, &#x27;v3get&#x27;, &#x27;v3set&#x27;,separated by commas,such as v1get,v1set,v2cget.</div>
+                                            <div>The input parameters are &#x27;v1get&#x27;, &#x27;v1set&#x27;, &#x27;v2cget&#x27;, &#x27;v2cset&#x27;, &#x27;v3get&#x27;, &#x27;v3set&#x27;, separated by commas, such as v1get, v1set, v2cget.</div>
                                             <div>Only the M5 models support this feature.</div>
                                                         </td>
             </tr>

--- a/docs/edit_snmp_module.rst
+++ b/docs/edit_snmp_module.rst
@@ -83,8 +83,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set auth password of V3 trap or v3get/v3set.</div>
-                                            <div>Password is a string of 8 to 16 alphanumeric characters.</div>
+                                            <div>Set the authentication password for the V3 trap or v3get/v3set.</div>
+                                            <div>The password is a string of 8 to 16 alphanumeric characters.</div>
                                             <div>Required when <em>auth_protocol</em> is either <code>SHA</code> or <code>MD5</code>.</div>
                                                         </td>
             </tr>
@@ -105,7 +105,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Choose authentication of V3 trap or v3get/v3set.</div>
+                                            <div>Choose the authentication protocol for the V3 trap or v3get/v3set.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -166,8 +166,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set privacy password of V3 trap or v3get/v3set.</div>
-                                            <div>Password is a string of 8 to 16 alphanumeric characters.</div>
+                                            <div>Set the privacy password for the V3 trap or v3get/v3set.</div>
+                                            <div>The password is a string of 8 to 16 alphanumeric characters.</div>
                                             <div>Required when <em>priv_protocol</em> is either <code>DES</code> or <code>AES</code>.</div>
                                                         </td>
             </tr>
@@ -188,7 +188,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Choose Privacy of V3 trap or v3get/v3set.</div>
+                                            <div>Choose the privacy protocol for the V3 trap or v3get/v3set.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -388,7 +388,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set user name of V3 trap or v3get/v3set.</div>
+                                            <div>Set a username for the V3 trap or v3get/v3set.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_snmp_trap_module.rst
+++ b/docs/edit_snmp_trap_module.rst
@@ -83,7 +83,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set auth password of V3 trap, password is a string of 8 to 16 alpha-numeric characters.</div>
+                                            <div>Set auth password of V3 trap, password is a string of 8 to 16 alphanumeric characters.</div>
                                             <div>Required when <em>auth_protocol</em> is either <code>SHA</code> or <code>MD5</code>.</div>
                                                         </td>
             </tr>
@@ -268,7 +268,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set privacy password of V3 trap, password is a string of 8 to 16 alpha-numeric characters.</div>
+                                            <div>Set privacy password of V3 trap, password is a string of 8 to 16 alphanumeric characters.</div>
                                             <div>Required when <em>priv_protocol</em> is either <code>DES</code> or <code>AES</code>.</div>
                                                         </td>
             </tr>

--- a/docs/edit_snmp_trap_module.rst
+++ b/docs/edit_snmp_trap_module.rst
@@ -452,7 +452,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>SNMP trap version,1 is v1,2 is v2c(v2),3 is v3,0 is disable snmp trap.</div>
+                                            <div>SNMP trap version, 1 is v1, 2 is v2c(v2), 3 is v3, 0 is disable snmp trap.</div>
                                             <div>Only the M6 model supports <code>0</code> Settings.</div>
                                                         </td>
             </tr>

--- a/docs/edit_snmp_trap_module.rst
+++ b/docs/edit_snmp_trap_module.rst
@@ -83,7 +83,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set auth password of V3 trap, password is a string of 8 to 16 alphanumeric characters.</div>
+                                            <div>Set the authentication password for the V3 trap.</div>
+                                            <div>The password is a string of 8 to 16 alphanumeric characters.</div>
                                             <div>Required when <em>auth_protocol</em> is either <code>SHA</code> or <code>MD5</code>.</div>
                                                         </td>
             </tr>
@@ -104,7 +105,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Choose authentication.</div>
+                                            <div>Choose the authentication protocol for the V3 trap.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -134,7 +135,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set contact, can set NULL.</div>
+                                            <div>Set the contact, can be NULL.</div>
                                             <div>Only the M5 model supports this parameter.</div>
                                                         </td>
             </tr>
@@ -150,7 +151,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set Engine ID of V3 trap, engine ID is a string of 10 to 48 hex characters, must even, can set NULL.</div>
+                                            <div>Specifies an engine identifier for the V3 trap. The value should be string of 10 to 48 hex characters, must be even, can be NULL.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -221,7 +222,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set host Location, can set NULL.</div>
+                                            <div>Set the host location, can be NULL.</div>
                                             <div>Only the M5 model supports this parameter.</div>
                                                         </td>
             </tr>
@@ -237,7 +238,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set host OS, can set NULL.</div>
+                                            <div>Set the host operating system, can be NULL.</div>
                                             <div>Only the M5 model supports this parameter.</div>
                                                         </td>
             </tr>
@@ -268,7 +269,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set privacy password of V3 trap, password is a string of 8 to 16 alphanumeric characters.</div>
+                                            <div>Set the privacy password for the V3 trap.</div>
+                                            <div>The password is a string of 8 to 16 alphanumeric characters.</div>
                                             <div>Required when <em>priv_protocol</em> is either <code>DES</code> or <code>AES</code>.</div>
                                                         </td>
             </tr>
@@ -289,7 +291,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Choose Privacy.</div>
+                                            <div>Choose the privacy protocol for the V3 trap.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -368,7 +370,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set system ID, can set NULL.</div>
+                                            <div>Set the system ID, can be NULL.</div>
                                             <div>Only the M5 model supports this parameter.</div>
                                                         </td>
             </tr>
@@ -384,7 +386,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set system name, can set NULL.</div>
+                                            <div>Set the system name, can be NULL.</div>
                                             <div>Only the M5 model supports this parameter.</div>
                                                         </td>
             </tr>
@@ -400,7 +402,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set SNMP trap Port(1-65535).</div>
+                                            <div>Set a port for the SNMP trap in the range of 1 to 65535.</div>
                                             <div>Only the M5 model supports this parameter.</div>
                                                         </td>
             </tr>
@@ -431,7 +433,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Set user name of V3 trap.</div>
+                                            <div>Set the username for the V3 trap.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_threshold_module.rst
+++ b/docs/edit_threshold_module.rst
@@ -98,7 +98,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Lower critical threshold,should be integer.</div>
+                                            <div>Lower critical threshold, should be integer.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -113,7 +113,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Lower non critical threshold,should be integer.</div>
+                                            <div>Lower non critical threshold, should be integer.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -128,7 +128,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Lower non recoverable threshold,should be integer.</div>
+                                            <div>Lower non recoverable threshold, should be integer.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -237,7 +237,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Up critical threshold,should be integer.</div>
+                                            <div>Up critical threshold, should be integer.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -252,7 +252,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Up non critical threshold,should be integer.</div>
+                                            <div>Up non critical threshold, should be integer.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -267,7 +267,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Up non recoverable threshold,should be integer.</div>
+                                            <div>Up non recoverable threshold, should be integer.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_virtual_media_module.rst
+++ b/docs/edit_virtual_media_module.rst
@@ -257,7 +257,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>To enable or disable Remote Media support, check or uncheck the checbox respectively.</div>
+                                            <div>To enable or disable Remote Media support, check or uncheck the checkbox respectively.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/edit_virtual_media_module.rst
+++ b/docs/edit_virtual_media_module.rst
@@ -102,7 +102,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>To enable or disable Local Media Support,check or uncheck the checkbox respectively.</div>
+                                            <div>To enable or disable Local Media Support, check or uncheck the checkbox respectively.</div>
                                             <div>Only the M5 model supports this parameter.</div>
                                                         </td>
             </tr>
@@ -238,7 +238,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Remote Domain Name,Domain Name field is optional.</div>
+                                            <div>Remote Domain Name, Domain Name field is optional.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -257,7 +257,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>To enable or disable Remote Media support,check or uncheck the checbox respectively.</div>
+                                            <div>To enable or disable Remote Media support, check or uncheck the checbox respectively.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -357,7 +357,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>Same settings with CD,0 is No,1 is Yes.</div>
+                                            <div>Same settings with CD, 0 is No, 1 is Yes.</div>
                                             <div>Required when <em>mount_type=0</em>.</div>
                                                         </td>
             </tr>

--- a/docs/network_info_module.rst
+++ b/docs/network_info_module.rst
@@ -42,7 +42,7 @@ Synopsis
 
 .. Description
 
-- Get netowrk information on kaytus Server.
+- Get network information on kaytus Server.
 
 
 .. Aliases

--- a/docs/update_fw_module.rst
+++ b/docs/update_fw_module.rst
@@ -108,7 +108,7 @@ Parameters
                                                                                     <b>Default:</b><br/><div style="color: blue">1</div>
                                     </td>
                                                                 <td>
-                                            <div>Update me or not when update bios,only work in INTEL platform,0-no,1-yes.</div>
+                                            <div>Update me or not when update bios, only work in INTEL platform, 0-no, 1-yes.</div>
                                             <div>Only the M5 model supports this parameter.</div>
                                                         </td>
             </tr>
@@ -163,7 +163,7 @@ Parameters
                                                                                     <b>Default:</b><br/><div style="color: blue">0</div>
                                     </td>
                                                                 <td>
-                                            <div>Reserve Configrations,0-reserve, 1-override.</div>
+                                            <div>Reserve Configrations, 0-reserve, 1-override.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/update_fw_module.rst
+++ b/docs/update_fw_module.rst
@@ -163,7 +163,7 @@ Parameters
                                                                                     <b>Default:</b><br/><div style="color: blue">0</div>
                                     </td>
                                                                 <td>
-                                            <div>Reserve Configrations, 0-reserve, 1-override.</div>
+                                            <div>Reserve Configurations, 0-reserve, 1-override.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/user_group_module.rst
+++ b/docs/user_group_module.rst
@@ -183,7 +183,7 @@ Parameters
                                                                                                                                                             </td>
                                                                 <td>
                                             <div>Group name.</div>
-                                            <div>The range of group name for M6 model is OEM1,OEM2,OEM3,OEM4.</div>
+                                            <div>The range of group name for M6 model is OEM1, OEM2, OEM3, OEM4.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/docs/user_module.rst
+++ b/docs/user_module.rst
@@ -268,7 +268,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>User id,The range is 1 to 16.</div>
+                                            <div>User id, The range is 1 to 16.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -283,7 +283,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>User name,Required when uid is None.</div>
+                                            <div>User name, Required when uid is None.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -357,7 +357,7 @@ Examples
           uname: "wbs"
           upass: "admin"
           role_id: "Administrator"
-          priv: "kvm,sol"
+          priv: "kvm, sol"
           email: "wbs@ieisystem.com"
           provider: "{{ ksmanage }}"
 
@@ -367,7 +367,7 @@ Examples
           uname: "wbs"
           upass: "12345678"
           role_id: "user"
-          priv: "kvm,sol"
+          priv: "kvm, sol"
           provider: "{{ ksmanage }}"
 
 

--- a/plugins/modules/add_ldisk.py
+++ b/plugins/modules/add_ldisk.py
@@ -28,7 +28,7 @@ options:
     ctrl_id:
         description:
             - Raid controller ID.
-            - Required when I(Info=None) and controller type is LSI,PMC or MV.
+            - Required when I(Info=None) and controller type is LSI, PMC or MV.
         type: int
     level:
         description:
@@ -39,9 +39,9 @@ options:
     size:
         description:
             - Strip Size, 0 - 32k, 1 - 64k, 2 - 128k, 3 - 256k, 4 - 512k, 5 - 1024k.
-            - Required when I(Info=None) and controller type is LSI,PMC or MV.
-            - When the controller type is MV,size is [0, 1].
-            - When the controller type is LSI or PMC,size is [1, 2, 3, 4, 5].
+            - Required when I(Info=None) and controller type is LSI, PMC or MV.
+            - When the controller type is MV, size is [0, 1].
+            - When the controller type is LSI or PMC, size is [1, 2, 3, 4, 5].
         choices: [0, 1, 2, 3, 4, 5]
         type: int
     access:
@@ -70,7 +70,7 @@ options:
         type: int
     cache:
         description:
-            - Drive Cache, 1 - Unchanged, 2 - Enabled,3 - Disabled.
+            - Drive Cache, 1 - Unchanged, 2 - Enabled, 3 - Disabled.
             - Required when I(Info=None) and controller type is LSI.
         choices: [1, 2, 3]
         type: int
@@ -87,7 +87,7 @@ options:
         type: int
     slot:
         description:
-            - Slot Num,input multiple slotNumber like 0,1,2....
+            - Slot Num, input multiple slotNumber like 0, 1, 2....
             - Required when I(Info=None) and controller type is LSI or PMC.
         type: list
         elements: int
@@ -137,7 +137,7 @@ EXAMPLES = '''
       cache: 1
       init: 2
       select: 10
-      slot: 0,1
+      slot: 0, 1
       provider: "{{ ksmanage }}"
 
   - name: "Add PMC ldisk"
@@ -146,7 +146,7 @@ EXAMPLES = '''
       level: 1
       size: 1
       accelerator: 1
-      slot: 0,1
+      slot: 0, 1
       vname: "test"
       provider: "{{ ksmanage }}"
 

--- a/plugins/modules/backup.py
+++ b/plugins/modules/backup.py
@@ -31,7 +31,8 @@ options:
             - The values for M5 modules are 'all', 'network', 'service', 'ntp', 'snmptrap', 'dns', 'smtp', 'ad', 'ldap', 'user', 'bios'.
             - The values for M6 modules are 'all', 'network', 'service', 'ntp', 'snmptrap',  'kvm', 'ipmi', 'authentication', 'syslog'.
             - The values for M7 modules are 'all', 'network', 'service', 'syslog', 'ncsi'.
-        choices: ['all', 'network', 'service', 'ntp', 'snmptrap', 'dns', 'smtp', 'ad', 'ldap', 'user', 'bios', 'kvm', 'ipmi', 'authentication', 'syslog', 'ncsi']
+        choices: ['all', 'network', 'service', 'ntp', 'snmptrap', 'dns', 'smtp', 'ad', 'ldap',
+         'user', 'bios', 'kvm', 'ipmi', 'authentication', 'syslog', 'ncsi']
         required: true
         type: str
 extends_documentation_fragment:

--- a/plugins/modules/backup.py
+++ b/plugins/modules/backup.py
@@ -28,10 +28,10 @@ options:
     item:
         description:
             - Export item.
-            - The values for M5 modules are 'all', 'network', 'service', 'ntp', 'snmptrap', 'dns', 'smtp', 'ad', 'ldap', 'user','bios'.
+            - The values for M5 modules are 'all', 'network', 'service', 'ntp', 'snmptrap', 'dns', 'smtp', 'ad', 'ldap', 'user', 'bios'.
             - The values for M6 modules are 'all', 'network', 'service', 'ntp', 'snmptrap',  'kvm', 'ipmi', 'authentication', 'syslog'.
             - The values for M7 modules are 'all', 'network', 'service', 'syslog', 'ncsi'.
-        choices: ['all', 'network', 'service', 'ntp', 'snmptrap', 'dns', 'smtp', 'ad', 'ldap', 'user','bios', 'kvm', 'ipmi', 'authentication', 'syslog', 'ncsi']
+        choices: ['all', 'network', 'service', 'ntp', 'snmptrap', 'dns', 'smtp', 'ad', 'ldap', 'user', 'bios', 'kvm', 'ipmi', 'authentication', 'syslog', 'ncsi']
         required: true
         type: str
 extends_documentation_fragment:

--- a/plugins/modules/bios_export.py
+++ b/plugins/modules/bios_export.py
@@ -22,7 +22,7 @@ notes:
 options:
     file_url:
         description:
-            - Suffix is .json/.conf, FILEURI format,"/directory/filename".
+            - Suffix is .json/.conf, FILEURI format, "/directory/filename".
         required: true
         type: str
 extends_documentation_fragment:

--- a/plugins/modules/bios_import.py
+++ b/plugins/modules/bios_import.py
@@ -22,7 +22,7 @@ notes:
 options:
     file_url:
         description:
-            - Suffix is .json/.conf, FILEURI format,"/directory/filename".
+            - Suffix is .json/.conf, FILEURI format, "/directory/filename".
         required: true
         type: str
 extends_documentation_fragment:

--- a/plugins/modules/collect_log.py
+++ b/plugins/modules/collect_log.py
@@ -16,7 +16,7 @@ author:
     - WangBaoshan (@ieisystem)
 short_description: Collect logs
 description:
-   - Collect logs on kaytus Server,it takes about 5 minutes.
+   - Collect logs on kaytus Server, it takes about 5 minutes.
 notes:
    - Does not support C(check_mode).
 options:

--- a/plugins/modules/edit_alert_policy.py
+++ b/plugins/modules/edit_alert_policy.py
@@ -41,9 +41,9 @@ options:
         type: str
     destination:
         description:
-            - Alert destination, when type is snmp, fill in IP.
-            - When type is email, fill in user name.
-            - When type is snmpdomain, fill in domain.
+            - Alert destination, when type is snmp, specify an IP address.
+            - When type is email, specify a username.
+            - When type is snmpdomain, specify a domain.
         type: str
     channel:
         description:

--- a/plugins/modules/edit_alert_policy.py
+++ b/plugins/modules/edit_alert_policy.py
@@ -23,8 +23,8 @@ options:
     id:
         description:
             - Alert id.
-            - The values for M5 modules are 1,2,3.
-            - The values for M6 modules are 1,2,3,4.
+            - The values for M5 modules are 1, 2, 3.
+            - The values for M6 modules are 1, 2, 3, 4.
         choices: [1, 2, 3, 4]
         required: true
         type: int
@@ -41,9 +41,9 @@ options:
         type: str
     destination:
         description:
-            - Alert destination,when type is snmp,fill in IP.
-            - When type is email,fill in user name.
-            - When type is snmpdomain,fill in domain.
+            - Alert destination, when type is snmp, fill in IP.
+            - When type is email, fill in user name.
+            - When type is snmpdomain, fill in domain.
         type: str
     channel:
         description:

--- a/plugins/modules/edit_bios.py
+++ b/plugins/modules/edit_bios.py
@@ -38,7 +38,7 @@ options:
     file_url:
         description:
             - BIOS option file.attribute must be used with value.
-            - Mutually exclusive with fileurl format,"/directory/filename".
+            - Mutually exclusive with fileurl format, "/directory/filename".
         type: str
 extends_documentation_fragment:
     - kaytus.ksmanage.ksmanage

--- a/plugins/modules/edit_dns.py
+++ b/plugins/modules/edit_dns.py
@@ -42,7 +42,7 @@ options:
         type: str
     domain_iface:
         description:
-            - Network Interface,input like 'eth0_v4', 'eth0_v6', 'eth1_v4', 'eth1_v6', 'bond0_v4', 'bond0_v6'.
+            - Network Interface, input like 'eth0_v4', 'eth0_v6', 'eth1_v4', 'eth1_v6', 'bond0_v4', 'bond0_v6'.
             - Required when I(domain_manual=auto).
         type: str
     domain_name:
@@ -57,7 +57,7 @@ options:
         type: str
     dns_iface:
         description:
-            - DNS Interface,input like 'eth0', 'eth1', 'bond0'.
+            - DNS Interface, input like 'eth0', 'eth1', 'bond0'.
             - Required when I(dns_manual=auto).
         type: str
     dns_priority:

--- a/plugins/modules/edit_fan.py
+++ b/plugins/modules/edit_fan.py
@@ -22,12 +22,12 @@ notes:
 options:
     mode:
         description:
-            - Control mode, Manual or Automatic ,Manual must be used with fans_peed.
+            - Control mode, Manual or Automatic , Manual must be used with fans_peed.
         choices: ['Automatic', 'Manual']
         type: str
     id:
         description:
-            - Fan id 255 is for all fans,0~n.
+            - Fan id 255 is for all fans, 0~n.
         type: int
     fan_speed:
         description:

--- a/plugins/modules/edit_fru.py
+++ b/plugins/modules/edit_fru.py
@@ -22,11 +22,11 @@ notes:
 options:
     attribute:
         description:
-            - CP is Chassis Part Number,CS is Chassis Serial,PM is Product Manufacturer.
-            - PPN is Product Part Number,PS is Product Serial,PN is Product Name.
-            - PV is Product Version,PAT is Product Asset Tag,BM is Board Mfg,BPN is Board Product Name.
-            - BS is Board Serial,BP is Board Part Number.
-        choices: ['CP', 'CS', 'PM', 'PPN', 'PS', 'PN', 'PV','PAT', 'BM', 'BPN', 'BS', 'BP']
+            - CP is Chassis Part Number, CS is Chassis Serial, PM is Product Manufacturer.
+            - PPN is Product Part Number, PS is Product Serial, PN is Product Name.
+            - PV is Product Version, PAT is Product Asset Tag, BM is Board Mfg, BPN is Board Product Name.
+            - BS is Board Serial, BP is Board Part Number.
+        choices: ['CP', 'CS', 'PM', 'PPN', 'PS', 'PN', 'PV', 'PAT', 'BM', 'BPN', 'BS', 'BP']
         required: true
         type: str
     value:

--- a/plugins/modules/edit_kvm.py
+++ b/plugins/modules/edit_kvm.py
@@ -43,10 +43,10 @@ options:
         description:
             - Select the Keyboard Language.
             - AD is Auto Detect, DA is Danish, NL-BE is Dutch Belgium, NL-NL is Dutch Netherland.
-            - GB is English UK ,US is English US, FI is Finnish, FR-BE is French Belgium, FR is French France.
+            - GB is English UK , US is English US, FI is Finnish, FR-BE is French Belgium, FR is French France.
             - DE is German Germany, DE-CH is German Switzerland, IT is Italian, JP is Japanese.
             - NO is Norwegian, PT is Portuguese, ES is Spanish, SV is Swedish, TR_F is Turkish F, TR_Q is Turkish Q.
-        choices: ['AD', 'DA', 'NL-BE', 'NL-NL', 'GB', 'US', 'FI', 'FR-BE', 'FR', 'DE', 'DE-CH', 'IT', 'JP', 'ON', 'PT', 'EC', 'SV', 'TR_F','TR_Q']
+        choices: ['AD', 'DA', 'NL-BE', 'NL-NL', 'GB', 'US', 'FI', 'FR-BE', 'FR', 'DE', 'DE-CH', 'IT', 'JP', 'ON', 'PT', 'EC', 'SV', 'TR_F', 'TR_Q']
         type: str
     retry_count:
         description:

--- a/plugins/modules/edit_ldap.py
+++ b/plugins/modules/edit_ldap.py
@@ -43,7 +43,7 @@ options:
             - Bind DN.
             - Bind DN is a string of 4 to 64 alphanumeric characters.
             - It must start with an alphabetical character.
-            - Special Symbols like dot(.), comma(,), hyphen(-), underscore(_), equal-to(=) are allowed.
+            - Special Symbols like dot(.), comma(, ), hyphen(-), underscore(_), equal-to(=) are allowed.
         type: str
     code:
         description:
@@ -55,7 +55,7 @@ options:
             - Search Base.
             - Search base is a string of 4 to 64 alphanumeric characters.
             - It must start with an alphabetical character.
-            - Special Symbols like dot(.), comma(,), hyphen(-), underscore(_), equal-to(=) are allowed.
+            - Special Symbols like dot(.), comma(, ), hyphen(-), underscore(_), equal-to(=) are allowed.
         type: str
     attr:
         description:
@@ -111,7 +111,7 @@ EXAMPLES = '''
       encry: "SSL"
       address: "100.2.2.2"
       server_port: 389
-      dn: "cn=manager,ou=login,dc=domain,dc=com"
+      dn: "cn=manager, ou=login, dc=domain, dc=com"
       code: "123456"
       base: "cn=manager"
       attr: "uid"

--- a/plugins/modules/edit_ldap.py
+++ b/plugins/modules/edit_ldap.py
@@ -41,7 +41,7 @@ options:
     dn:
         description:
             - Bind DN.
-            - Bind DN is a string of 4 to 64 alpha-numeric characters.
+            - Bind DN is a string of 4 to 64 alphanumeric characters.
             - It must start with an alphabetical character.
             - Special Symbols like dot(.), comma(,), hyphen(-), underscore(_), equal-to(=) are allowed.
         type: str
@@ -53,7 +53,7 @@ options:
     base:
         description:
             - Search Base.
-            - Search base is a string of 4 to 64 alpha-numeric characters.
+            - Search base is a string of 4 to 64 alphanumeric characters.
             - It must start with an alphabetical character.
             - Special Symbols like dot(.), comma(,), hyphen(-), underscore(_), equal-to(=) are allowed.
         type: str

--- a/plugins/modules/edit_ldisk.py
+++ b/plugins/modules/edit_ldisk.py
@@ -38,15 +38,15 @@ options:
     option:
         description:
             - Set operation options for a logical disk.
-            - LOC is Locate Logical Drive,STL is Stop Locate LogicalDrive.
-            - FI is Fast Initialization,SFI is Slow/Full Initialization.
-            - SI is Stop Initialization,DEL is Delete LogicalDrive.
+            - LOC is Locate Logical Drive, STL is Stop Locate LogicalDrive.
+            - FI is Fast Initialization, SFI is Slow/Full Initialization.
+            - SI is Stop Initialization, DEL is Delete LogicalDrive.
             - Required when I(Info=None).
         choices: ['LOC', 'STL', 'FI', 'SFI', 'SI', 'DEL']
         type: str
     duration:
         description:
-            - Duration range is 1-255,physical drive under PMC raid controller.
+            - Duration range is 1-255, physical drive under PMC raid controller.
             - Required when I(option=LOC).
             - Only the M6 model supports this parameter.
         type: int

--- a/plugins/modules/edit_ldisk.py
+++ b/plugins/modules/edit_ldisk.py
@@ -37,7 +37,7 @@ options:
         type: int
     option:
         description:
-            - Set operation options fo logical disk.
+            - Set operation options for a logical disk.
             - LOC is Locate Logical Drive,STL is Stop Locate LogicalDrive.
             - FI is Fast Initialization,SFI is Slow/Full Initialization.
             - SI is Stop Initialization,DEL is Delete LogicalDrive.

--- a/plugins/modules/edit_m6_log_setting.py
+++ b/plugins/modules/edit_m6_log_setting.py
@@ -28,40 +28,40 @@ options:
         type: str
     host_tag:
         description:
-            - System log host tag,set when I(status=enable).
+            - System log host tag, set when I(status=enable).
         choices: ['HostName', 'SerialNum', 'AssertTag']
         type: str
     level:
         description:
-            - Events Level,set when I(status=enable).
+            - Events Level, set when I(status=enable).
         choices: ['Critical', 'Warning', 'Info']
         type: str
     protocol_type:
         description:
-            - Protocol Type,set when I(status=enable).
+            - Protocol Type, set when I(status=enable).
         choices: ['UDP', 'TCP']
         type: str
     server_id:
         description:
-            - Syslog Server ID,set when I(status=enable).
+            - Syslog Server ID, set when I(status=enable).
         choices: [0, 1, 2, 3]
         type: int
     server_addr:
         description:
-            - Server Address,set when server_id is not none.
+            - Server Address, set when server_id is not none.
         type: str
     server_port:
         description:
-            - Server Address,set when server_id is not none.
+            - Server Address, set when server_id is not none.
         type: int
     log_type:
         description:
-            - Remote Log Type,set when server_id is not none.
+            - Remote Log Type, set when server_id is not none.
         choices: ['idl', 'audit', 'both']
         type: str
     test:
         description:
-            - Test remote log settings,set when server_id is not none.
+            - Test remote log settings, set when server_id is not none.
         default: False
         type: bool
 extends_documentation_fragment:

--- a/plugins/modules/edit_ncsi.py
+++ b/plugins/modules/edit_ncsi.py
@@ -24,8 +24,8 @@ options:
         description:
             - Nic type.
             - Only NF3280A6 and NF3180A6 model supports C(Disable) Settings, but not support C(PHY) Settings.
-            - M6 model only support C(OCP),C(OCP1),C(PCIE) settings.
-        choices: ['PHY', 'OCP','OCP1', 'PCIE', 'auto', 'Disable']
+            - M6 model only support C(OCP), C(OCP1), C(PCIE) settings.
+        choices: ['PHY', 'OCP', 'OCP1', 'PCIE', 'auto', 'Disable']
         type: str
     mode:
         description:

--- a/plugins/modules/edit_network.py
+++ b/plugins/modules/edit_network.py
@@ -16,7 +16,7 @@ author:
     - WangBaoshan (@ieisystem)
 short_description: Set network information
 description:
-   - Set netowrk information on kaytus Server.
+   - Set network information on kaytus Server.
 notes:
    - Does not support C(check_mode).
 options:

--- a/plugins/modules/edit_network_bond.py
+++ b/plugins/modules/edit_network_bond.py
@@ -22,7 +22,7 @@ notes:
 options:
     bond:
         description:
-            - Network bond status,If VLAN is enabled for slave interfaces, then Bonding cannot be enabled.
+            - Network bond status, If VLAN is enabled for slave interfaces, then Bonding cannot be enabled.
         choices: ['enable', 'disable']
         type: str
     interface:

--- a/plugins/modules/edit_ntp.py
+++ b/plugins/modules/edit_ntp.py
@@ -32,7 +32,7 @@ options:
         type: str
     time_zone:
         description:
-            - UTC time zone,chose from {-12, -11.5, -11, ... ,11,11.5,12}.
+            - UTC time zone, chose from {-12, -11.5, -11, ... , 11, 11.5, 12}.
         type: str
     server1:
         description:
@@ -60,11 +60,11 @@ options:
         type: str
     syn_cycle:
         description:
-            - NTP syn cycle(minute),sync cycle(5-1440).
+            - NTP syn cycle(minute), sync cycle(5-1440).
         type: int
     max_variety:
         description:
-            - NTP Maximum jump time(minute),max variety(1-60).
+            - NTP Maximum jump time(minute), max variety(1-60).
             - Only the M6 model supports this parameter.
         type: int
 extends_documentation_fragment:

--- a/plugins/modules/edit_pdisk.py
+++ b/plugins/modules/edit_pdisk.py
@@ -37,7 +37,7 @@ options:
         type: int
     option:
         description:
-            - Set operation options fo physical disk.
+            - Set operation options for a physical disk.
             - UG is Unconfigured Good,UB is Unconfigured Bad.
             - OFF is offline,FAIL is Failed,RBD is Rebuild.
             - ON is Online,JB is JBOD,ES is Drive Erase stop.

--- a/plugins/modules/edit_pdisk.py
+++ b/plugins/modules/edit_pdisk.py
@@ -38,11 +38,11 @@ options:
     option:
         description:
             - Set operation options for a physical disk.
-            - UG is Unconfigured Good,UB is Unconfigured Bad.
-            - OFF is offline,FAIL is Failed,RBD is Rebuild.
-            - ON is Online,JB is JBOD,ES is Drive Erase stop.
-            - EM is Drive Erase Simple,EN is Drive Erase Normal.
-            - ET is Drive Erase Through,LOC is Locate,STL is Stop Locate.
+            - UG is Unconfigured Good, UB is Unconfigured Bad.
+            - OFF is offline, FAIL is Failed, RBD is Rebuild.
+            - ON is Online, JB is JBOD, ES is Drive Erase stop.
+            - EM is Drive Erase Simple, EN is Drive Erase Normal.
+            - ET is Drive Erase Through, LOC is Locate, STL is Stop Locate.
             - HS is Hot spare.
             - Required when I(Info=None).
             - Only the M5 model supports C(HS) Settings.
@@ -71,14 +71,14 @@ options:
         type: str
     logical_drivers:
         description:
-            - Logical Drivers while set physical drive hotspare, input multiple Logical Drivers index like 0,1,2.....
+            - Logical Drivers while set physical drive hotspare, input multiple Logical Drivers index like 0, 1, 2.....
             - Required when I(Info=None) and I(option=HS) and I(action=dedicate).
             - Only the M5 model supports this parameter.
         type: list
         elements: int
     duration:
         description:
-            - Duration range is 1-255,physical drive under PMC raid controller.
+            - Duration range is 1-255, physical drive under PMC raid controller.
             - Required when I(option=LOC).
             - Only the M6 model supports this parameter.
         type: int

--- a/plugins/modules/edit_power_budget.py
+++ b/plugins/modules/edit_power_budget.py
@@ -65,7 +65,8 @@ options:
         type: int
     week1:
         description:
-            - Pause period of add, repetition period, the input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
+            - Pause period of add, repetition period.
+            - The input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
         type: list
         elements: str
     start2:
@@ -78,7 +79,8 @@ options:
         type: int
     week2:
         description:
-            - Pause period of add, repetition period, the input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
+            - Pause period of add, repetition period.
+            - The input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
         type: list
         elements: str
     start3:
@@ -91,7 +93,8 @@ options:
         type: int
     week3:
         description:
-            - Pause period of add, repetition period, the input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
+            - Pause period of add, repetition period.
+            - The input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
         type: list
         elements: str
     start4:
@@ -104,7 +107,8 @@ options:
         type: int
     week4:
         description:
-            - Pause period of add, repetition period, the input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
+            - Pause period of add, repetition period.
+            - The input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
         type: list
         elements: str
     start5:
@@ -117,7 +121,8 @@ options:
         type: int
     week5:
         description:
-            - Pause period of add, repetition period, the input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
+            - Pause period of add, repetition period.
+            - The input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
         type: list
         elements: str
 extends_documentation_fragment:

--- a/plugins/modules/edit_power_budget.py
+++ b/plugins/modules/edit_power_budget.py
@@ -61,11 +61,11 @@ options:
         type: int
     end1:
         description:
-            - Pause period of add, end time,must be greater than start time,from 0 to 24.
+            - Pause period of add, end time, must be greater than start time, from 0 to 24.
         type: int
     week1:
         description:
-            - Pause period of add,repetition period,the input parameters are 'Mon','Tue','Wed','Thur','Fri','Sat','Sun',separated by commas,such as Mon,Wed,Fri.
+            - Pause period of add, repetition period, the input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
         type: list
         elements: str
     start2:
@@ -74,11 +74,11 @@ options:
         type: int
     end2:
         description:
-            - Pause period of add, end time,must be greater than start time,from 0 to 24.
+            - Pause period of add, end time, must be greater than start time, from 0 to 24.
         type: int
     week2:
         description:
-            - Pause period of add,repetition period,the input parameters are 'Mon','Tue','Wed','Thur','Fri','Sat','Sun',separated by commas,such as Mon,Wed,Fri.
+            - Pause period of add, repetition period, the input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
         type: list
         elements: str
     start3:
@@ -87,11 +87,11 @@ options:
         type: int
     end3:
         description:
-            - Pause period of add, end time,must be greater than start time,from 0 to 24.
+            - Pause period of add, end time, must be greater than start time, from 0 to 24.
         type: int
     week3:
         description:
-            - Pause period of add,repetition period,the input parameters are 'Mon','Tue','Wed','Thur','Fri','Sat','Sun',separated by commas,such as Mon,Wed,Fri.
+            - Pause period of add, repetition period, the input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
         type: list
         elements: str
     start4:
@@ -100,11 +100,11 @@ options:
         type: int
     end4:
         description:
-            - Pause period of add, end time,must be greater than start time,from 0 to 24.
+            - Pause period of add, end time, must be greater than start time, from 0 to 24.
         type: int
     week4:
         description:
-            - Pause period of add,repetition period,the input parameters are 'Mon','Tue','Wed','Thur','Fri','Sat','Sun',separated by commas,such as Mon,Wed,Fri.
+            - Pause period of add, repetition period, the input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
         type: list
         elements: str
     start5:
@@ -113,11 +113,11 @@ options:
         type: int
     end5:
         description:
-            - Pause period of add, end time,must be greater than start time,from 0 to 24.
+            - Pause period of add, end time, must be greater than start time, from 0 to 24.
         type: int
     week5:
         description:
-            - Pause period of add,repetition period,the input parameters are 'Mon','Tue','Wed','Thur','Fri','Sat','Sun',separated by commas,such as Mon,Wed,Fri.
+            - Pause period of add, repetition period, the input parameters are 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun', separated by commas, such as Mon, Wed, Fri.
         type: list
         elements: str
 extends_documentation_fragment:

--- a/plugins/modules/edit_smtp.py
+++ b/plugins/modules/edit_smtp.py
@@ -23,7 +23,7 @@ notes:
 options:
     interface:
         description:
-            - LAN Channel,eth0 is shared,eth1 is dedicated.
+            - LAN Channel, eth0 is shared, eth1 is dedicated.
         choices: ['eth0', 'eth1', 'bond0']
         type: str
         required: true
@@ -46,7 +46,7 @@ options:
         type: str
     primary_port:
         description:
-            - Primary SMTP server port,The Identification for retry count configuration(1-65535).
+            - Primary SMTP server port, The Identification for retry count configuration(1-65535).
         type: int
     primary_auth:
         description:
@@ -55,12 +55,12 @@ options:
         type: str
     primary_username:
         description:
-            - Primary SMTP server Username,length be 4 to 64 bits.
-            - Must start with letters and cannot contain ','(comma) ':'(colon) ' '(space) ';'(semicolon) '\\'(backslash).
+            - Primary SMTP server Username, length be 4 to 64 bits.
+            - Must start with letters and cannot contain ', '(comma) ':'(colon) ' '(space) ';'(semicolon) '\\'(backslash).
         type: str
     primary_password:
         description:
-            - Primary SMTP server Password,length be 4 to 64 bits,cannot contain ' '(space).
+            - Primary SMTP server Password, length be 4 to 64 bits, cannot contain ' '(space).
             - Required when I(primary_auth=enable).
         type: str
     secondary_status:
@@ -78,7 +78,7 @@ options:
         type: str
     secondary_port:
         description:
-            - Secondary SMTP server port,The Identification for retry count configuration(1-65535).
+            - Secondary SMTP server port, The Identification for retry count configuration(1-65535).
         type: int
     secondary_auth:
         description:
@@ -87,12 +87,12 @@ options:
         type: str
     secondary_username:
         description:
-            - Secondary SMTP server Username,length be 4 to 64 bits.
-            - Must start with letters and cannot contain ','(comma) ':'(colon) ' '(space) ';'(semicolon) '\\'(backslash).
+            - Secondary SMTP server Username, length be 4 to 64 bits.
+            - Must start with letters and cannot contain ', '(comma) ':'(colon) ' '(space) ';'(semicolon) '\\'(backslash).
         type: str
     secondary_password:
         description:
-            - Secondary SMTP server Password,length be 4 to 64 bits,cannot contain ' '(space).
+            - Secondary SMTP server Password, length be 4 to 64 bits, cannot contain ' '(space).
             - Required when I(secondary_auth=enable).
         type: str
 extends_documentation_fragment:

--- a/plugins/modules/edit_smtp.py
+++ b/plugins/modules/edit_smtp.py
@@ -55,12 +55,12 @@ options:
         type: str
     primary_username:
         description:
-            - Primary SMTP server Username,lenth be 4 to 64 bits.
+            - Primary SMTP server Username,length be 4 to 64 bits.
             - Must start with letters and cannot contain ','(comma) ':'(colon) ' '(space) ';'(semicolon) '\\'(backslash).
         type: str
     primary_password:
         description:
-            - Primary SMTP server Password,lenth be 4 to 64 bits,cannot contain ' '(space).
+            - Primary SMTP server Password,length be 4 to 64 bits,cannot contain ' '(space).
             - Required when I(primary_auth=enable).
         type: str
     secondary_status:
@@ -87,12 +87,12 @@ options:
         type: str
     secondary_username:
         description:
-            - Secondary SMTP server Username,lenth be 4 to 64 bits.
+            - Secondary SMTP server Username,length be 4 to 64 bits.
             - Must start with letters and cannot contain ','(comma) ':'(colon) ' '(space) ';'(semicolon) '\\'(backslash).
         type: str
     secondary_password:
         description:
-            - Secondary SMTP server Password,lenth be 4 to 64 bits,cannot contain ' '(space).
+            - Secondary SMTP server Password,length be 4 to 64 bits,cannot contain ' '(space).
             - Required when I(secondary_auth=enable).
         type: str
 extends_documentation_fragment:

--- a/plugins/modules/edit_smtp_com.py
+++ b/plugins/modules/edit_smtp_com.py
@@ -33,11 +33,11 @@ options:
         type: str
     server_port:
         description:
-            - SMTP server port,The Identification for retry count configuration(1-65535).
+            - SMTP server port, The Identification for retry count configuration(1-65535).
         type: int
     server_secure_port:
         description:
-            - SMTP server sesure port,The Identification for retry count configuration(1-65535).
+            - SMTP server sesure port, The Identification for retry count configuration(1-65535).
         type: int
     email:
         description:
@@ -50,13 +50,13 @@ options:
         type: str
     server_username:
         description:
-            - SMTP server Username,length be 4 to 64 bits.
-            - Must start with letters and cannot contain ','(comma) ':'(colon) ' '(space) ';'(semicolon) '\\'(backslash).
+            - SMTP server Username, length be 4 to 64 bits.
+            - Must start with letters and cannot contain ', '(comma) ':'(colon) ' '(space) ';'(semicolon) '\\'(backslash).
             - Required when I(server_auth=enable).
         type: str
     server_password:
         description:
-            - SMTP server Password,length be 4 to 64 bits,cannot contain ' '(space).
+            - SMTP server Password, length be 4 to 64 bits, cannot contain ' '(space).
             - Required when I(server_auth=enable).
         type: str
     ssl_tls_enable:

--- a/plugins/modules/edit_smtp_com.py
+++ b/plugins/modules/edit_smtp_com.py
@@ -50,13 +50,13 @@ options:
         type: str
     server_username:
         description:
-            - SMTP server Username,lenth be 4 to 64 bits.
+            - SMTP server Username,length be 4 to 64 bits.
             - Must start with letters and cannot contain ','(comma) ':'(colon) ' '(space) ';'(semicolon) '\\'(backslash).
             - Required when I(server_auth=enable).
         type: str
     server_password:
         description:
-            - SMTP server Password,lenth be 4 to 64 bits,cannot contain ' '(space).
+            - SMTP server Password,length be 4 to 64 bits,cannot contain ' '(space).
             - Required when I(server_auth=enable).
         type: str
     ssl_tls_enable:

--- a/plugins/modules/edit_snmp.py
+++ b/plugins/modules/edit_snmp.py
@@ -65,28 +65,28 @@ options:
         type: str
     v3username:
         description:
-            - Set user name of V3 trap or v3get/v3set.
+            - Set a username for the V3 trap or v3get/v3set.
         type: str
     auth_protocol:
         description:
-            - Choose authentication of V3 trap or v3get/v3set.
+            - Choose the authentication protocol for the V3 trap or v3get/v3set.
         choices: ['NONE', 'SHA', 'MD5']
         type: str
     auth_password:
         description:
-            - Set auth password of V3 trap or v3get/v3set.
-            - Password is a string of 8 to 16 alphanumeric characters.
+            - Set the authentication password for the V3 trap or v3get/v3set.
+            - The password is a string of 8 to 16 alphanumeric characters.
             - Required when I(auth_protocol) is either C(SHA) or C(MD5).
         type: str
     priv_protocol:
         description:
-            - Choose Privacy of V3 trap or v3get/v3set.
+            - Choose the privacy protocol for the V3 trap or v3get/v3set.
         choices: ['NONE', 'DES', 'AES']
         type: str
     priv_password:
         description:
-            - Set privacy password of V3 trap or v3get/v3set.
-            - Password is a string of 8 to 16 alphanumeric characters.
+            - Set the privacy password for the V3 trap or v3get/v3set.
+            - The password is a string of 8 to 16 alphanumeric characters.
             - Required when I(priv_protocol) is either C(DES) or C(AES).
         type: str
 extends_documentation_fragment:

--- a/plugins/modules/edit_snmp.py
+++ b/plugins/modules/edit_snmp.py
@@ -29,7 +29,7 @@ options:
     snmp_status:
         description:
             - NMP read/write status of customize.
-            - The input parameters are 'v1get', 'v1set', 'v2cget', 'v2cset', 'v3get', 'v3set',separated by commas,such as v1get,v1set,v2cget.
+            - The input parameters are 'v1get', 'v1set', 'v2cget', 'v2cset', 'v3get', 'v3set', separated by commas, such as v1get, v1set, v2cget.
             - Only the M5 models support this feature.
         type: list
         elements: str
@@ -55,12 +55,12 @@ options:
         type: str
     read_community:
         description:
-            - Read Only Community,Community should between 1 and 16 characters.
+            - Read Only Community, Community should between 1 and 16 characters.
             - Only the M6 models support this feature.
         type: str
     read_write_community:
         description:
-            - Read And Write Community,Community should between 1 and 16 characters.
+            - Read And Write Community, Community should between 1 and 16 characters.
             - Only the M6 models support this feature.
         type: str
     v3username:

--- a/plugins/modules/edit_snmp.py
+++ b/plugins/modules/edit_snmp.py
@@ -75,7 +75,7 @@ options:
     auth_password:
         description:
             - Set auth password of V3 trap or v3get/v3set.
-            - Password is a string of 8 to 16 alpha-numeric characters.
+            - Password is a string of 8 to 16 alphanumeric characters.
             - Required when I(auth_protocol) is either C(SHA) or C(MD5).
         type: str
     priv_protocol:
@@ -86,7 +86,7 @@ options:
     priv_password:
         description:
             - Set privacy password of V3 trap or v3get/v3set.
-            - Password is a string of 8 to 16 alpha-numeric characters.
+            - Password is a string of 8 to 16 alphanumeric characters.
             - Required when I(priv_protocol) is either C(DES) or C(AES).
         type: str
 extends_documentation_fragment:

--- a/plugins/modules/edit_snmp_trap.py
+++ b/plugins/modules/edit_snmp_trap.py
@@ -22,7 +22,7 @@ notes:
 options:
     version:
         description:
-            - SNMP trap version,1 is v1,2 is v2c(v2),3 is v3,0 is disable snmp trap.
+            - SNMP trap version, 1 is v1, 2 is v2c(v2), 3 is v3, 0 is disable snmp trap.
             - Only the M6 model supports C(0) Settings.
         choices: [0, 1, 2, 3]
         type: int

--- a/plugins/modules/edit_snmp_trap.py
+++ b/plugins/modules/edit_snmp_trap.py
@@ -43,60 +43,62 @@ options:
         type: str
     v3username:
         description:
-            - Set user name of V3 trap.
+            - Set the username for the V3 trap.
         type: str
     engine_id:
         description:
-            - Set Engine ID of V3 trap, engine ID is a string of 10 to 48 hex characters, must even, can set NULL.
+            - Specifies an engine identifier for the V3 trap. The value should be string of 10 to 48 hex characters, must be even, can be NULL.
         type: str
     auth_protocol:
         description:
-            - Choose authentication.
+            - Choose the authentication protocol for the V3 trap.
         choices: ['NONE', 'SHA', 'MD5']
         type: str
     auth_password:
         description:
-            - Set auth password of V3 trap, password is a string of 8 to 16 alphanumeric characters.
+            - Set the authentication password for the V3 trap.
+            - The password is a string of 8 to 16 alphanumeric characters.
             - Required when I(auth_protocol) is either C(SHA) or C(MD5).
         type: str
     priv_protocol:
         description:
-            - Choose Privacy.
+            - Choose the privacy protocol for the V3 trap.
         choices: ['NONE', 'DES', 'AES']
         type: str
     priv_password:
         description:
-            - Set privacy password of V3 trap, password is a string of 8 to 16 alphanumeric characters.
+            - Set the privacy password for the V3 trap.
+            - The password is a string of 8 to 16 alphanumeric characters.
             - Required when I(priv_protocol) is either C(DES) or C(AES).
         type: str
     system_name:
         description:
-            - Set system name, can set NULL.
+            - Set the system name, can be NULL.
             - Only the M5 model supports this parameter.
         type: str
     system_id:
         description:
-            - Set system ID, can set NULL.
+            - Set the system ID, can be NULL.
             - Only the M5 model supports this parameter.
         type: str
     location:
         description:
-            - Set host Location, can set NULL.
+            - Set the host location, can be NULL.
             - Only the M5 model supports this parameter.
         type: str
     contact:
         description:
-            - Set contact, can set NULL.
+            - Set the contact, can be NULL.
             - Only the M5 model supports this parameter.
         type: str
     os:
         description:
-            - Set host OS, can set NULL.
+            - Set the host operating system, can be NULL.
             - Only the M5 model supports this parameter.
         type: str
     trap_port:
         description:
-            - Set SNMP trap Port(1-65535).
+            - Set a port for the SNMP trap in the range of 1 to 65535.
             - Only the M5 model supports this parameter.
         type: int
 extends_documentation_fragment:

--- a/plugins/modules/edit_snmp_trap.py
+++ b/plugins/modules/edit_snmp_trap.py
@@ -56,7 +56,7 @@ options:
         type: str
     auth_password:
         description:
-            - Set auth password of V3 trap, password is a string of 8 to 16 alpha-numeric characters.
+            - Set auth password of V3 trap, password is a string of 8 to 16 alphanumeric characters.
             - Required when I(auth_protocol) is either C(SHA) or C(MD5).
         type: str
     priv_protocol:
@@ -66,7 +66,7 @@ options:
         type: str
     priv_password:
         description:
-            - Set privacy password of V3 trap, password is a string of 8 to 16 alpha-numeric characters.
+            - Set privacy password of V3 trap, password is a string of 8 to 16 alphanumeric characters.
             - Required when I(priv_protocol) is either C(DES) or C(AES).
         type: str
     system_name:

--- a/plugins/modules/edit_threshold.py
+++ b/plugins/modules/edit_threshold.py
@@ -27,27 +27,27 @@ options:
         required: true
     lnr:
         description:
-            - Lower non recoverable threshold,should be integer.
+            - Lower non recoverable threshold, should be integer.
         type: int
     lc:
         description:
-            - Lower critical threshold,should be integer.
+            - Lower critical threshold, should be integer.
         type: int
     lnc:
         description:
-            - Lower non critical threshold,should be integer.
+            - Lower non critical threshold, should be integer.
         type: int
     unc:
         description:
-            - Up non critical threshold,should be integer.
+            - Up non critical threshold, should be integer.
         type: int
     uc:
         description:
-            - Up critical threshold,should be integer.
+            - Up critical threshold, should be integer.
         type: int
     unr:
         description:
-            - Up non recoverable threshold,should be integer.
+            - Up non recoverable threshold, should be integer.
         type: int
 extends_documentation_fragment:
     - kaytus.ksmanage.ksmanage

--- a/plugins/modules/edit_virtual_media.py
+++ b/plugins/modules/edit_virtual_media.py
@@ -28,7 +28,7 @@ options:
         type: str
     remote_media_support:
         description:
-            - To enable or disable Remote Media support,check or uncheck the checbox respectively.
+            - To enable or disable Remote Media support,check or uncheck the checkbox respectively.
         choices: ['Enable', 'Disable']
         type: str
     mount_type:

--- a/plugins/modules/edit_virtual_media.py
+++ b/plugins/modules/edit_virtual_media.py
@@ -22,13 +22,13 @@ notes:
 options:
     local_media_support:
         description:
-            - To enable or disable Local Media Support,check or uncheck the checkbox respectively.
+            - To enable or disable Local Media Support, check or uncheck the checkbox respectively.
             - Only the M5 model supports this parameter.
         choices: ['Enable', 'Disable']
         type: str
     remote_media_support:
         description:
-            - To enable or disable Remote Media support,check or uncheck the checkbox respectively.
+            - To enable or disable Remote Media support, check or uncheck the checkbox respectively.
         choices: ['Enable', 'Disable']
         type: str
     mount_type:
@@ -39,7 +39,7 @@ options:
         type: str
     same_settings:
         description:
-            - Same settings with CD,0 is No,1 is Yes.
+            - Same settings with CD, 0 is No, 1 is Yes.
             - Required when I(mount_type=0).
         choices: [0, 1]
         type: int
@@ -64,7 +64,7 @@ options:
         type: str
     remote_domain_name:
         description:
-            - Remote Domain Name,Domain Name field is optional.
+            - Remote Domain Name, Domain Name field is optional.
         type: str
     remote_user_name:
         description:

--- a/plugins/modules/network_info.py
+++ b/plugins/modules/network_info.py
@@ -16,7 +16,7 @@ author:
     - WangBaoshan (@ieisystem)
 short_description: Get network information
 description:
-   - Get netowrk information on kaytus Server.
+   - Get network information on kaytus Server.
 notes:
    - Supports C(check_mode).
 options: {}

--- a/plugins/modules/restore.py
+++ b/plugins/modules/restore.py
@@ -29,7 +29,7 @@ options:
         description:
             - Select export item.
             - Only the M5 model supports this parameter.
-        choices: ['all', 'network', 'dns', 'service', 'ntp', 'smtp', 'snmptrap', 'ad', 'ldap', 'user','bios']
+        choices: ['all', 'network', 'dns', 'service', 'ntp', 'smtp', 'snmptrap', 'ad', 'ldap', 'user', 'bios']
         type: str
 extends_documentation_fragment:
     - kaytus.ksmanage.ksmanage

--- a/plugins/modules/update_fw.py
+++ b/plugins/modules/update_fw.py
@@ -38,13 +38,13 @@ options:
         type: str
     over_ride:
         description:
-            - Reserve Configurations,0-reserve, 1-override.
+            - Reserve Configurations, 0-reserve, 1-override.
         default: 0
         choices: [0, 1]
         type: int
     has_me:
         description:
-            - Update me or not when update bios,only work in INTEL platform,0-no,1-yes.
+            - Update me or not when update bios, only work in INTEL platform, 0-no, 1-yes.
             - Only the M5 model supports this parameter.
         default: 1
         choices: [0, 1]

--- a/plugins/modules/update_fw.py
+++ b/plugins/modules/update_fw.py
@@ -38,7 +38,7 @@ options:
         type: str
     over_ride:
         description:
-            - Reserve Configrations,0-reserve, 1-override.
+            - Reserve Configurations,0-reserve, 1-override.
         default: 0
         choices: [0, 1]
         type: int

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -28,11 +28,11 @@ options:
         type: str
     uid:
         description:
-            - User id,The range is 1 to 16.
+            - User id, The range is 1 to 16.
         type: int
     uname:
         description:
-            - User name,Required when uid is None.
+            - User name, Required when uid is None.
         type: str
     upass:
         description:
@@ -83,7 +83,7 @@ EXAMPLES = '''
       uname: "wbs"
       upass: "admin"
       role_id: "Administrator"
-      priv: "kvm,sol"
+      priv: "kvm, sol"
       email: "wbs@ieisystem.com"
       provider: "{{ ksmanage }}"
 
@@ -93,7 +93,7 @@ EXAMPLES = '''
       uname: "wbs"
       upass: "12345678"
       role_id: "user"
-      priv: "kvm,sol"
+      priv: "kvm, sol"
       provider: "{{ ksmanage }}"
 '''
 

--- a/plugins/modules/user_group.py
+++ b/plugins/modules/user_group.py
@@ -29,7 +29,7 @@ options:
     name:
         description:
             - Group name.
-            - The range of group name for M6 model is OEM1,OEM2,OEM3,OEM4.
+            - The range of group name for M6 model is OEM1, OEM2, OEM3, OEM4.
         required: true
         type: str
     pri:


### PR DESCRIPTION
As mentioned in https://github.com/ansible-collections/ansible-inclusion/discussions/69 

This PR makes some updates to module documentation to add spaces after commas, corrects some spelling issues, and clarifies language in some instances.

This PR is not comprehensive and does not update all modules for clarity. Rather this PR is intended to illustrate some of the changes that could help improve documentation. Some suggestions that can be applied throughout the module documentation:

- Use articles before nouns (a, an, the).
- Capitalize only proper nouns or words that are capitalized in the user interface or wherever they appear to users.
- Avoid abbreviating words unnecessarily. For example, use "authentication" not "auth".
- Try not to use the same word or language as the thing you are describing.
- Include the complete term instead of the short form. For example, use "IP address" instead of "IP".

Hope this PR helps!